### PR TITLE
Fix sqlalchemy reserved metadata attribute

### DIFF
--- a/telegram-ytdl-bot/database/models.py
+++ b/telegram-ytdl-bot/database/models.py
@@ -121,7 +121,7 @@ class Download(Base):
     retry_count = Column(Integer, default=0)
     
     # Additional metadata
-    metadata = Column(JSON, default={})
+    extra_metadata = Column(JSON, default={})
     
     # Relationships
     user = relationship('User', back_populates='downloads')
@@ -159,7 +159,7 @@ class Payment(Base):
     completed_at = Column(DateTime, nullable=True)
     
     # Additional data
-    metadata = Column(JSON, default={})
+    extra_metadata = Column(JSON, default={})
     
     # Relationships
     user = relationship('User', back_populates='payments')

--- a/telegram-ytdl-bot/services/downloader.py
+++ b/telegram-ytdl-bot/services/downloader.py
@@ -541,7 +541,7 @@ class DownloadService:
             title=info['title'],
             duration=info['duration'],
             quality=quality,
-            metadata=info
+            extra_metadata=info
         )
         
         # Add to queue based on priority

--- a/telegram-ytdl-bot/services/uploader.py
+++ b/telegram-ytdl-bot/services/uploader.py
@@ -399,7 +399,7 @@ class ChunkedUploader:
     
     def _prepare_caption(self, download_info: Any, file_size: int) -> str:
         """Prepare caption for uploaded file"""
-        metadata = download_info.metadata or {}
+        metadata = download_info.extra_metadata or {}
         
         caption = f"📹 **{download_info.title or 'Unknown'}**\n\n"
         


### PR DESCRIPTION
Rename `metadata` attribute to `extra_metadata` in SQLAlchemy models to resolve `InvalidRequestError`.

The `metadata` attribute name is reserved in SQLAlchemy's Declarative API, leading to application startup failures. Renaming it to `extra_metadata` in the `Download` and `Payment` models, and updating all references, resolves this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-c236809c-5216-45b7-9796-365f97d8f7a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c236809c-5216-45b7-9796-365f97d8f7a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

