### PR TITLE
Fix pyrogram import error in downloader

### DIFF
--- a/telegram-ytdl-bot/utils/errors.py
+++ b/telegram-ytdl-bot/utils/errors.py
@@ -10,9 +10,8 @@ from pyrogram.types import Message, CallbackQuery
 from pyrogram.errors import (
     FloodWait, UserBlocked, UserDeactivated, ChatWriteForbidden,
     MessageNotModified, MessageIdInvalid, MessageDeleteForbidden,
-    BadRequest, Unauthorized, Forbidden, NotFound, Conflict,
-    BadRequest, Unauthorized, Forbidden, RPCError, Conflict,
-    ServerError, NetworkError
+    BadRequest, Unauthorized, Forbidden, Conflict,
+    RPCError, ServerError, NetworkError
 )
 
 from database.manager import db_manager


### PR DESCRIPTION
Remove non-existent `NotFound` and duplicate error imports from `pyrogram.errors` to fix `ImportError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-68157564-8af3-4cfe-9c86-7c9499384cba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68157564-8af3-4cfe-9c86-7c9499384cba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

